### PR TITLE
Fix the parent element example in the XPath section

### DIFF
--- a/selectors/example.js
+++ b/selectors/example.js
@@ -80,8 +80,8 @@ describe('selectors', () => {
         const paragraph = await $('//body/p[2]')
         await expect(paragraph).toHaveText('barfoo')
 
-        // const parent = await paragraph.$('..')
-        // expect(await parent.getTagName()).toBe('body')
+        const parent = await paragraph.parentElement();
+        expect(await parent.getTagName()).toBe('body')
     })
 
     describe('aria', () => {


### PR DESCRIPTION
`..` doesn't appear to work any more. See https://github.com/webdriverio/webdriverio/issues/13652